### PR TITLE
Hide randomizer ad free links on support page

### DIFF
--- a/randomizer-support.html
+++ b/randomizer-support.html
@@ -72,7 +72,7 @@
         <ul>
             <li>Schreibe eine E-Mail an: <a href="mailto:info@develohp.de">info@develohp.de</a></li>
         </ul>
-        <p>Weitere Informationen zum Datenschutz findest du in der Datenschutzerklärung: <a href="https://develohp.de/randomizer-privacy.html">Randomizer</a>, <a href="https://develohp.de/randomizer-privacy-adfree.html">Randomizer Ad Free</a>.</p>
+        <p>Weitere Informationen zum Datenschutz findest du in der Datenschutzerklärung: <a href="https://develohp.de/randomizer-privacy.html">Randomizer</a><!-- , <a href="https://develohp.de/randomizer-privacy-adfree.html">Randomizer Ad Free</a> -->.</p>
     </div>
 
     <div class="content english">
@@ -81,7 +81,7 @@
         <ul>
             <li>Email: <a href="mailto:info@develohp.de">info@develohp.de</a></li>
         </ul>
-        <p>For more information about privacy, see the Privacy Policy: <a href="https://develohp.de/randomizer-privacy.html">Randomizer</a>, <a href="https://develohp.de/randomizer-privacy-adfree.html">Randomizer Ad Free</a>.</p>
+        <p>For more information about privacy, see the Privacy Policy: <a href="https://develohp.de/randomizer-privacy.html">Randomizer</a><!-- , <a href="https://develohp.de/randomizer-privacy-adfree.html">Randomizer Ad Free</a> -->.</p>
     </div>
 
     <script>


### PR DESCRIPTION
Hide Randomizer Ad Free links on the Support Page as only the regular Randomizer has been released.